### PR TITLE
Make serde actually optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ serde_json = "1.0"
 postcard = {version = "1.0.4", features = ["alloc"] }
 
 [features]
-default = ["serde"]
+default = []
+serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bit-struct"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "Define structs which have fields which are assigned to individual bits, not bytes"
 repository = "https://github.com/parallelsystems/bit-struct"


### PR DESCRIPTION
Continues the work in #15 and fixes #13. It does make the breaking change that serde is not enabled by default. Users of this library would have to explicitly enable the serde feature to use the serde parts of the code. The version number should be 0.4.0 if this gets merged.
I can also revert that part if you want, and it would just be 0.3.3 with users having to wait for serde to compile if they do not disable default features.